### PR TITLE
feat(macro) Add catalog name to useLingui macro

### DIFF
--- a/packages/babel-plugin-extract-messages/package.json
+++ b/packages/babel-plugin-extract-messages/package.json
@@ -43,8 +43,8 @@
     "@babel/core": "^7.21.0",
     "@babel/traverse": "^7.20.12",
     "@babel/types": "^7.20.7",
-    "@lingui/babel-plugin-lingui-macro": "workspace:*",
     "@lingui/jest-mocks": "workspace:*",
+    "@whoosh.bike/babel-plugin-lingui-macro": "workspace:*",
     "unbuild": "2.0.0"
   }
 }

--- a/packages/babel-plugin-extract-messages/test/index.ts
+++ b/packages/babel-plugin-extract-messages/test/index.ts
@@ -5,7 +5,7 @@ import plugin, { ExtractedMessage, ExtractPluginOpts } from "../src/index"
 import { mockConsole } from "@lingui/jest-mocks"
 import linguiMacroPlugin, {
   type LinguiPluginOpts,
-} from "@lingui/babel-plugin-lingui-macro"
+} from "@whoosh.bike/babel-plugin-lingui-macro"
 
 const transform = (filename: string) => {
   const rootDir = path.join(__dirname, "fixtures")

--- a/packages/babel-plugin-lingui-macro/README.md
+++ b/packages/babel-plugin-lingui-macro/README.md
@@ -2,17 +2,17 @@
 [![Version][badge-version]][package]
 [![Downloads][badge-downloads]][package]
 
-# @lingui/babel-plugin-lingui-macro
+# @whoosh.bike/babel-plugin-lingui-macro
 
 > Babel plugin that does actual transforms of Lingui's Macros
 
-`@lingui/babel-plugin-lingui-macro` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
+`@whoosh.bike/babel-plugin-lingui-macro` is part of [LinguiJS][linguijs]. See the [documentation][documentation] for all information, tutorials and examples.
 
 ## Installation
 
 ```sh
-npm install --save-dev @lingui/babel-plugin-lingui-macro
-# yarn add --dev @lingui/babel-plugin-lingui-macro
+npm install --save-dev @whoosh.bike/babel-plugin-lingui-macro
+# yarn add --dev @whoosh.bike/babel-plugin-lingui-macro
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ npm install --save-dev @lingui/babel-plugin-lingui-macro
 
 ```json
 {
-  "plugins": ["@lingui/babel-plugin-lingui-macro"]
+  "plugins": ["@whoosh.bike/babel-plugin-lingui-macro"]
 }
 ```
 
@@ -34,7 +34,7 @@ npm install --save-dev @lingui/babel-plugin-lingui-macro
 [license]: https://github.com/lingui/js-lingui/blob/main/LICENSE
 [linguijs]: https://github.com/lingui/js-lingui
 [documentation]: https://lingui.dev
-[package]: https://www.npmjs.com/package/@lingui/babel-plugin-lingui-macro
-[badge-downloads]: https://img.shields.io/npm/dw/@lingui/babel-plugin-lingui-macro.svg
-[badge-version]: https://img.shields.io/npm/v/@lingui/babel-plugin-lingui-macro.svg
-[badge-license]: https://img.shields.io/npm/l/@lingui/babel-plugin-lingui-macro.svg
+[package]: https://www.npmjs.com/package/@whoosh.bike/babel-plugin-lingui-macro
+[badge-downloads]: https://img.shields.io/npm/dw/@whoosh.bike/babel-plugin-lingui-macro.svg
+[badge-version]: https://img.shields.io/npm/v/@whoosh.bike/babel-plugin-lingui-macro.svg
+[badge-license]: https://img.shields.io/npm/l/@whoosh.bike/babel-plugin-lingui-macro.svg

--- a/packages/babel-plugin-lingui-macro/package.json
+++ b/packages/babel-plugin-lingui-macro/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lingui/babel-plugin-lingui-macro",
+  "name": "@whoosh.bike/babel-plugin-lingui-macro",
   "version": "5.3.0",
   "description": "Babel plugin for transforming Lingui Macros",
   "main": "./dist/index.cjs",
@@ -72,10 +72,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/lingui/js-lingui.git"
+    "url": "https://github.com/whoosh-bike/js-lingui.git"
   },
   "bugs": {
-    "url": "https://github.com/lingui/js-lingui/issues"
+    "url": "https://github.com/whoosh-bike/js-lingui/issues"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -9,6 +9,7 @@ import {
   type LinguiConfigNormalized,
   getConfig as loadConfig,
 } from "@lingui/conf"
+import { getCatalogName } from "./utils/getCatalogName"
 
 let config: LinguiConfigNormalized
 
@@ -236,6 +237,10 @@ export default function ({
                 state: PluginPass
               ) {
                 const macro = new MacroJs({
+                  catalogName: getCatalogName(
+                    state.filename,
+                    state.get("linguiConfig")
+                  ),
                   stripNonEssentialProps:
                     process.env.NODE_ENV == "production" &&
                     !(state.opts as LinguiPluginOpts).extract,

--- a/packages/babel-plugin-lingui-macro/src/macroJs.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJs.ts
@@ -23,6 +23,7 @@ import {
 } from "./macroJsAst"
 
 export type MacroJsOpts = {
+  catalogName: string | void
   i18nImportName: string
   useLinguiImportName: string
 
@@ -32,6 +33,7 @@ export type MacroJsOpts = {
 }
 
 export class MacroJs {
+  catalogName: string | void
   // Identifier of i18n object
   i18nImportName: string
   useLinguiImportName: string
@@ -42,6 +44,7 @@ export class MacroJs {
   _ctx: MacroJsContext
 
   constructor(opts: MacroJsOpts) {
+    this.catalogName = opts.catalogName
     this.i18nImportName = opts.i18nImportName
     this.useLinguiImportName = opts.useLinguiImportName
 
@@ -241,7 +244,16 @@ export class MacroJs {
         )
       : null
 
-    const newNode = t.callExpression(t.identifier(this.useLinguiImportName), [])
+    const useLinguiArguments = []
+
+    if (this.catalogName) {
+      useLinguiArguments.push(t.stringLiteral(this.catalogName))
+    }
+
+    const newNode = t.callExpression(
+      t.identifier(this.useLinguiImportName),
+      useLinguiArguments
+    )
 
     if (!_property) {
       return newNode
@@ -310,7 +322,10 @@ export class MacroJs {
     _property.key.name = "_"
     _property.value.name = uniqTIdentifier.name
 
-    return t.callExpression(t.identifier(this.useLinguiImportName), [])
+    return t.callExpression(
+      t.identifier(this.useLinguiImportName),
+      useLinguiArguments
+    )
   }
 
   private createI18nCall(

--- a/packages/babel-plugin-lingui-macro/src/utils/getCatalogName.ts
+++ b/packages/babel-plugin-lingui-macro/src/utils/getCatalogName.ts
@@ -1,0 +1,17 @@
+import type { LinguiConfigNormalized } from "@lingui/conf"
+
+export function getCatalogName(
+  path: string,
+  config: LinguiConfigNormalized
+): string | void | never {
+  for (const catalog of config.catalogs) {
+    const re = new RegExp(
+      catalog.include.join("|").replace(/{name}/g, "([^/]+)")
+    )
+    const match = path.match(re)
+
+    if (match) {
+      return catalog.name ?? match[1]
+    }
+  }
+}

--- a/packages/babel-plugin-lingui-macro/test/macroTester.ts
+++ b/packages/babel-plugin-lingui-macro/test/macroTester.ts
@@ -3,7 +3,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import linguiMacroPlugin, {
   LinguiPluginOpts,
-} from "@lingui/babel-plugin-lingui-macro"
+} from "@whoosh.bike/babel-plugin-lingui-macro"
 import { transformFileSync, transformSync, TransformOptions } from "@babel/core"
 import prettier from "prettier"
 import path from "path"

--- a/packages/babel-plugin-lingui-macro/test/utils/getCatalogName.test.ts
+++ b/packages/babel-plugin-lingui-macro/test/utils/getCatalogName.test.ts
@@ -1,0 +1,130 @@
+import { makeConfig } from "@lingui/conf"
+import { getCatalogName } from "../../src/utils/getCatalogName"
+
+describe("getCatalogName", () => {
+  it("returns undefined when catalogs is empty", () => {
+    const actual = getCatalogName(
+      "src/App.tsx",
+      makeConfig({
+        locales: ["en"],
+        catalogs: [],
+      })
+    )
+
+    expect(actual).toBeUndefined()
+  })
+
+  it("returns undefined when path does not match any include patterns", () => {
+    const actual = getCatalogName(
+      "other/path/file.tsx",
+      makeConfig({
+        locales: ["en"],
+        catalogs: [
+          {
+            path: "locales/{locale}",
+            include: ["src"],
+          },
+        ],
+      })
+    )
+
+    expect(actual).toBeUndefined()
+  })
+
+  it("returns undefined when does not have specific catalog", () => {
+    const actual = getCatalogName(
+      "src/App.tsx",
+      makeConfig({
+        locales: ["en"],
+        catalogs: [
+          {
+            path: "locales/{locale}",
+            include: ["src"],
+          },
+        ],
+      })
+    )
+
+    expect(actual).toBeUndefined()
+  })
+
+  it("returns name when catalog has it in config", () => {
+    const actual = getCatalogName(
+      "src/App.tsx",
+      makeConfig({
+        locales: ["en"],
+        catalogs: [
+          {
+            name: "test-catalog",
+            path: "locales/{locale}",
+            include: ["src"],
+          },
+        ],
+      })
+    )
+
+    expect(actual).toBe("test-catalog")
+  })
+
+  it("returns name when catalog has it in path pattern", () => {
+    const actual = getCatalogName(
+      "src/features/test/Test.tsx",
+      makeConfig({
+        locales: ["en"],
+        catalogs: [
+          {
+            path: "src/features/{name}/{locale}",
+            include: ["src/features/{name}"],
+          },
+        ],
+      })
+    )
+
+    expect(actual).toBe("test")
+  })
+
+  it("returns name when catalog has several include patterns", () => {
+    const actual = getCatalogName(
+      "src/features/test/Test.tsx",
+      makeConfig({
+        locales: ["en"],
+        catalogs: [
+          {
+            path: "src/features/{name}/{locale}",
+            include: ["src/features/{name}", "src/pages/{name}"],
+          },
+        ],
+      })
+    )
+
+    expect(actual).toBe("test")
+  })
+
+  it("handles multiple catalogs and returns first match", () => {
+    const actual = getCatalogName(
+      "src/features/auth/Login.tsx",
+      makeConfig({
+        locales: ["en"],
+        catalogs: [
+          {
+            name: "main",
+            path: "locales/{locale}",
+            include: ["src/common"],
+          },
+          {
+            name: "auth",
+            path: "src/features/auth/{locale}",
+            include: ["src/features/auth"],
+          },
+          {
+            name: "other",
+            path: "src/features/{name}/{locale}",
+            include: ["src/features/other"],
+          },
+        ],
+      })
+    )
+
+    expect(actual).toBe("auth")
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2631,34 +2631,30 @@ __metadata:
     "@babel/core": ^7.21.0
     "@babel/traverse": ^7.20.12
     "@babel/types": ^7.20.7
-    "@lingui/babel-plugin-lingui-macro": "workspace:*"
     "@lingui/jest-mocks": "workspace:*"
+    "@whoosh.bike/babel-plugin-lingui-macro": "workspace:*"
     unbuild: 2.0.0
   languageName: unknown
   linkType: soft
 
-"@lingui/babel-plugin-lingui-macro@5.3.0, @lingui/babel-plugin-lingui-macro@workspace:*, @lingui/babel-plugin-lingui-macro@workspace:packages/babel-plugin-lingui-macro":
-  version: 0.0.0-use.local
-  resolution: "@lingui/babel-plugin-lingui-macro@workspace:packages/babel-plugin-lingui-macro"
+"@lingui/babel-plugin-lingui-macro@npm:5.3.0":
+  version: 5.3.0
+  resolution: "@lingui/babel-plugin-lingui-macro@npm:5.3.0"
   dependencies:
     "@babel/core": ^7.20.12
-    "@babel/parser": ^7.20.15
     "@babel/runtime": ^7.20.13
-    "@babel/traverse": ^7.20.12
     "@babel/types": ^7.20.7
     "@lingui/conf": 5.3.0
     "@lingui/core": 5.3.0
     "@lingui/message-utils": 5.3.0
-    "@types/babel-plugin-macros": ^2.8.5
-    prettier: 2.8.3
-    unbuild: 2.0.0
   peerDependencies:
     babel-plugin-macros: 2 || 3
   peerDependenciesMeta:
     babel-plugin-macros:
       optional: true
-  languageName: unknown
-  linkType: soft
+  checksum: 83576c24ff5365882268c8924654e2483cbcafd0206fd2b9e0a1be7013acabc9ffba78549126f23076718bc9fce40d7006ccc1e82145ef9f37a35a1ac1f8c2c3
+  languageName: node
+  linkType: hard
 
 "@lingui/cli@5.3.0, @lingui/cli@workspace:*, @lingui/cli@workspace:packages/cli":
   version: 0.0.0-use.local
@@ -4725,6 +4721,29 @@ __metadata:
   checksum: f15ae4c2441b979a3b4fce78f3d83472fb22350c6dc3fd34bfe7c3da108e0b2360718734d961bba20e7716cb8578e964b870da55b035e209e50ec9db0378a3f7
   languageName: node
   linkType: hard
+
+"@whoosh.bike/babel-plugin-lingui-macro@workspace:*, @whoosh.bike/babel-plugin-lingui-macro@workspace:packages/babel-plugin-lingui-macro":
+  version: 0.0.0-use.local
+  resolution: "@whoosh.bike/babel-plugin-lingui-macro@workspace:packages/babel-plugin-lingui-macro"
+  dependencies:
+    "@babel/core": ^7.20.12
+    "@babel/parser": ^7.20.15
+    "@babel/runtime": ^7.20.13
+    "@babel/traverse": ^7.20.12
+    "@babel/types": ^7.20.7
+    "@lingui/conf": 5.3.0
+    "@lingui/core": 5.3.0
+    "@lingui/message-utils": 5.3.0
+    "@types/babel-plugin-macros": ^2.8.5
+    prettier: 2.8.3
+    unbuild: 2.0.0
+  peerDependencies:
+    babel-plugin-macros: 2 || 3
+  peerDependenciesMeta:
+    babel-plugin-macros:
+      optional: true
+  languageName: unknown
+  linkType: soft
 
 "@xtuc/ieee754@npm:^1.2.0":
   version: 1.2.0


### PR DESCRIPTION
### How It Works

The function examines the file path and checks if it matches any of the patterns defined in the configuration's catalogs. If there's a match, it returns the name of the matching catalog.

### Important Logic Flows

- When there are no catalogs defined in the configuration it returns undefined.
- When the file path doesn't match any of the include patterns in the catalogs, it returns undefined.
- When there are catalogs but none specifically for the given file, it returns undefined.
- When a catalog has an explicit name in the configuration and the file matches its include pattern, it returns that name.
- When a catalog uses a pattern with a `{name}` placeholder in its path, the function extracts and returns the matching part of the file path.
- When there are multiple catalogs defined, it returns the name of the first catalog that matches the file path.