### PR TITLE
feat(macro) Trans now supports separated catalogs

### DIFF
--- a/packages/babel-plugin-lingui-macro/src/constants.ts
+++ b/packages/babel-plugin-lingui-macro/src/constants.ts
@@ -1,5 +1,7 @@
 export const EXTRACT_MARK = "i18n"
 
+export const NAMESPACE_PROP_NAME = "ns"
+
 export enum MsgDescriptorPropKey {
   id = "id",
   message = "message",

--- a/packages/babel-plugin-lingui-macro/src/index.ts
+++ b/packages/babel-plugin-lingui-macro/src/index.ts
@@ -273,6 +273,10 @@ export default function ({
                 const macro = new MacroJSX(
                   { types: t },
                   {
+                    catalogName: getCatalogName(
+                      state.filename,
+                      state.get("linguiConfig")
+                    ),
                     transImportName: getSymbolIdentifier(state, "Trans").name,
                     descriptorFields: resolveDescriptorFields(
                       state.opts as LinguiPluginOpts,

--- a/packages/babel-plugin-lingui-macro/src/macroJsx.ts
+++ b/packages/babel-plugin-lingui-macro/src/macroJsx.ts
@@ -18,7 +18,7 @@ import type { NodePath } from "@babel/traverse"
 
 import { ArgToken, ElementToken, TextToken, Token } from "./icu"
 import { makeCounter } from "./utils"
-import { JsxMacroName, MsgDescriptorPropKey, JsMacroName } from "./constants"
+import { JsxMacroName, MsgDescriptorPropKey, JsMacroName, NAMESPACE_PROP_NAME } from "./constants"
 import cleanJSXElementLiteralChild from "./utils/cleanJSXElementLiteralChild"
 import {
   createMessageDescriptorFromTokens,
@@ -55,6 +55,7 @@ export type MacroJsxContext = MacroJsContext & {
   elementsTracking: Map<string, JSXElement>
   jsxPlaceholderAttribute?: string
   jsxPlaceholderDefaults?: Record<string, string>
+  catalogName: string | undefined
 }
 
 export type MacroJsxOpts = {
@@ -63,6 +64,7 @@ export type MacroJsxOpts = {
   isLinguiIdentifier: (node: Identifier, macro: JsMacroName) => boolean
   jsxPlaceholderAttribute?: string
   jsxPlaceholderDefaults?: Record<string, string>
+  catalogName?: string
 }
 
 const choiceComponentAttributesWhitelist = [
@@ -87,6 +89,7 @@ export class MacroJSX {
 
     this.ctx = {
       ...createMacroJsContext(opts.isLinguiIdentifier, opts.descriptorFields),
+      catalogName: opts.catalogName,
       transImportName: opts.transImportName,
       elementIndex: makeCounter(),
       elementsTracking: new Map(),
@@ -126,6 +129,13 @@ export class MacroJSX {
     )
 
     attributes.push(this.types.jsxSpreadAttribute(messageDescriptor))
+
+    if (this.ctx.catalogName) {
+      attributes.push(this.types.jsxAttribute(
+        this.types.jsxIdentifier(NAMESPACE_PROP_NAME),
+        this.types.stringLiteral(this.ctx.catalogName)
+      ))
+    }
 
     const newNode = this.types.jsxElement(
       this.types.jsxOpeningElement(

--- a/packages/babel-plugin-lingui-macro/src/utils/getCatalogName.ts
+++ b/packages/babel-plugin-lingui-macro/src/utils/getCatalogName.ts
@@ -5,6 +5,8 @@ export function getCatalogName(
   config: LinguiConfigNormalized
 ): string | void | never {
   for (const catalog of config.catalogs) {
+    if (!catalog.include) continue
+
     const re = new RegExp(
       catalog.include
         .map((s) => s

--- a/packages/vite-plugin/src/linguiTransformerPreset.ts
+++ b/packages/vite-plugin/src/linguiTransformerPreset.ts
@@ -59,7 +59,7 @@ export const linguiTransformerBabelPreset = (
 
   return {
     preset: {
-      plugins: [["@lingui/babel-plugin-lingui-macro", options]],
+      plugins: [["@whoosh.bike/babel-plugin-lingui-macro", options]],
     },
     rolldown: {
       filter: {

--- a/packages/vite-plugin/test/lingui-transformer-preset.test.ts
+++ b/packages/vite-plugin/test/lingui-transformer-preset.test.ts
@@ -21,7 +21,7 @@ describe("linguiTransformerBabelPreset", () => {
         "preset": {
           "plugins": [
             [
-              "@lingui/babel-plugin-lingui-macro",
+              "@whoosh.bike/babel-plugin-lingui-macro",
               {},
             ],
           ],
@@ -57,7 +57,7 @@ describe("linguiTransformerBabelPreset", () => {
         "preset": {
           "plugins": [
             [
-              "@lingui/babel-plugin-lingui-macro",
+              "@whoosh.bike/babel-plugin-lingui-macro",
               {},
             ],
           ],


### PR DESCRIPTION
### How It Works

Out internal implementation of `<Trans>` has `ns` prop and now it will be substituted by a macro

```jsx
<Trans>Hello {name}</Trans>

// ↓ ↓ ↓ ↓ ↓ ↓

<InternalTrans ns="feature-name">Hello {name}</InternalTrans>
```